### PR TITLE
fix regression with typography #78, fix footer alignment #77

### DIFF
--- a/blocks/footer/footer.css
+++ b/blocks/footer/footer.css
@@ -78,8 +78,8 @@
   cursor: pointer;
 }
 
-.footer .footer-truck-list__title,
-.footer .footer-newsletter__title {
+.footer-truck-list__title,
+.footer-newsletter__title {
   font-family: var(--ff-body-bold);
   font-size: 12px;
   line-height: 16px;

--- a/blocks/footer/footer.css
+++ b/blocks/footer/footer.css
@@ -78,11 +78,14 @@
   cursor: pointer;
 }
 
-.footer-truck-list__title, .footer-newsletter__title {
-  font-family: var(--ff-body);
+.footer .footer-truck-list__title,
+.footer .footer-newsletter__title {
+  font-family: var(--ff-body-bold);
   font-size: 12px;
   line-height: 16px;
   letter-spacing: 1.92px;
+  text-transform: uppercase;
+  color: var(--c-primary-white);
 }
 
 .footer-truck-list__title .icon-dropdown-caret {
@@ -113,7 +116,7 @@
   padding: 0 32px 16px;
   color: var(--c-primary-white);
   font-family: var(--ff-body);
-  font-size: var(--body-1-font-size);
+  font-size: 16px;
   line-height: var(--body-1-line-height);
   letter-spacing: 0.16px;
   justify-content: flex-start;
@@ -165,7 +168,7 @@
 .footer-menu__column a {
   color: var(--c-secondary-silver);
   font-family: var(--ff-body);
-  font-size: var(--body-2-font-size);
+  font-size: 13px;
   line-height: var(--body-2-line-height);
 }
 
@@ -179,8 +182,8 @@
   grid-area: newsletter;
 }
 
+/* stylelint-disable-next-line no-descending-specificity */
 .footer-newsletter__title {
-  color: var(--c-primary-white);
   margin-bottom: 12px;
 }
 
@@ -213,9 +216,9 @@
   border: none;
   color: var(--c-secondary-graphite);
   font-family: var(--ff-body);
-  font-size: var(--body-2-font-size);
+  font-size: 13px;
   height: 48px;
-  line-height: var(--body-2-font-size);
+  line-height: 13px;
   padding: 14px 48px 14px 14px;
 }
 
@@ -451,7 +454,6 @@
   }
 
   .footer-truck-list__title {
-    font-family: var(--ff-subheadings-medium);
     margin: 0 auto 0 0;
     padding: 24px 32px 24px 0;
     cursor: default;

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -844,8 +844,8 @@ main .section.responsive-title h1 {
 }
 
 /* stylelint-disable-next-line no-descending-specificity */
-.redesign-v2 h1, .redesign-v2 h2, .redesign-v2 h3,
-.redesign-v2 h4, .redesign-v2 h5, .redesign-v2 h6,
+:where(.redesign-v2) h1, :where(.redesign-v2) h2, :where(.redesign-v2) h3,
+:where(.redesign-v2) h4, :where(.redesign-v2) h5, :where(.redesign-v2) h6,
 .h1, .h2, .h3,
 .h4, .h5, .h6 {
   font-family: var(--ff-subheadings-medium);
@@ -853,31 +853,31 @@ main .section.responsive-title h1 {
 }
 
 /* stylelint-disable-next-line no-descending-specificity */
-.redesign-v2 h1, .h1 {
+:where(.redesign-v2) h1, .h1 {
   font-size: var(--headline-1-font-size);
   line-height: var(--headline-1-line-height);
   letter-spacing: var(--headline-1-letter-spacing);
 }
 
 /* stylelint-disable-next-line no-descending-specificity */
-.redesign-v2 h2, .h2 {
+:where(.redesign-v2) h2, .h2 {
   font-size: var(--headline-2-font-size);
   line-height: var(--headline-2-line-height);
   letter-spacing: var(--headline-2-letter-spacing);
 }
 
 /* stylelint-disable-next-line no-descending-specificity */
-.redesign-v2 h3, .h3 {
+:where(.redesign-v2) h3, .h3 {
   font-size: var(--headline-3-font-size);
   line-height: var(--headline-3-line-height);
 }
 
-.redesign-v2 h4, .h4 {
+:where(.redesign-v2) h4, .h4 {
   font-size: var(--headline-4-font-size);
   line-height: var(--headline-4-line-height);
 }
 
-.redesign-v2 h5, .h5 {
+:where(.redesign-v2) h5, .h5 {
   font-size: var(--headline-5-font-size);
   line-height: var(--headline-5-line-height);
 }

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -85,66 +85,29 @@
   /* Font sizes */
 
   /* GT America, Extended Medium, 45px, 115%, -2% / 32px, 115%, -2% */
-  --headline-1-font-size: 2rem; /* 32px */
+  --headline-1-font-size: 3.2rem; /* 32px */
   --headline-1-line-height: 115%;
   --headline-1-letter-spacing: -2%;
 
   /* GT America, Extended Medium, 32px, 115%, -2% / 28px, 115%, -2% */
-  --headline-2-font-size: 1.75rem; /* 28px */
+  --headline-2-font-size: 2.8rem; /* 28px */
   --headline-2-line-height: 115%;
   --headline-2-letter-spacing: -2%;
 
   /* Helvetica Neue LT Pro, 65 Medium, 32px, 115% / 28px, 115% */
-  --headline-3-font-size: 1.75rem; /* 28px */
+  --headline-3-font-size: 2.8rem; /* 28px */
   --headline-3-line-height: 115%;
 
   /* Helvetica Neue LT Pro, 65 Medium, 24px, 140%  */
-  --headline-4-font-size: 1.5rem; /* 24px */
+  --headline-4-font-size: 2.4rem; /* 24px */
   --headline-4-line-height: 140%;
 
   /* Helvetica Neue LT Pro, 65 Medium, 18px, 140%  */
   --headline-5-font-size: 1.125rem; /* 18px */
   --headline-5-line-height: 140%;
 
-  /* Helvetica Neue LT Pro, 55 Roman / Helvetica Neue LT Pro, 75 Bold, 16px, 150%  */
-  --body-1-font-size: 1rem; /* 16px */
-  --body-1-line-height: 150%;
-
-  /* Helvetica Neue LT Pro, 55 Roman / Helvetica Neue LT Pro, 75 Bold, 13px, 160%  */
-  --body-2-font-size: 0.813rem; /* 13px */
-  --body-2-line-height: 160%;
-
-  /* GT America Mono, Regular, 18px, 120% */
-  --accent-1-font-size: 1.125rem; /* 18px */
-  --accent-1-line-height: 120%;
-
-  /* GT America Mono, Regular, 14px, 120% */
-  --accent-2-font-size: 0.875rem; /* 14px */
-  --accent-2-line-height: 120%;
-
-  /* Helvetica Neue LT Pro, 75 Bold, 14px, 16px */
-  --label-font-size: 0.875rem; /* 14px */
-  --label-line-height: 16px;
-
-  /* Helvetica Neue LT Pro, 55 Roman, 14px, 18px */
-  --button-font-size: 0.875rem; /* 14px */
-  --button-line-height: 18px;
-
-  /* GT America, Extended Roman, 24px, 120%, -2% / 18px, 120%, -2% */
-  --testimonial-font-size: 1.125rem; /* 18px */
-  --testimonial-line-height: 120%;
-  --testimonial-letter-spacing: -2%;
-
-  /* Motions */
-  --duration-small: 160ms;
-  --duration-medium: 240ms;
-  --duration-large: 320ms;
-  --easing-entrance: cubic-bezier(0, 0, 0.4, 1);
-  --easing-exit: cubic-bezier(0.2, 0, 1, 1);
-  --easing-standard: cubic-bezier(0.2, 0, 0.1, 1);
-
-  /* In page navigation */
-  --inpage-navigation-height: 0;
+  /* Wrapper for generic components */
+  --wrapper-width: 1040px;
 
   /*
   OLD STYLES
@@ -160,13 +123,13 @@
   --ff-accents-regular: "GT America Mono Regular", var(--fallback-ff-accents);
 
   /* Body font sizes */
-  --body-font-size-xxl: 1.5rem; /* 24px */
-  --body-font-size-xl: 1.375rem; /* 22px */
-  --body-font-size-l: 1.25rem; /* 20px */
-  --body-font-size-m: 1.125rem; /* 18px */
-  --body-font-size-s: 1rem; /* 16px */
-  --body-font-size-xs: 0.875rem; /* 14px */
-  --body-font-size-xxs: 0.813rem; /* 13px */
+  --body-font-size-xxl: 2.4rem; /* 24px */
+  --body-font-size-xl: 2.2rem; /* 22px */
+  --body-font-size-l: 2rem; /* 20px */
+  --body-font-size-m: 1.8rem; /* 18px */
+  --body-font-size-s: 1.6rem; /* 16px */
+  --body-font-size-xs: 1.4rem; /* 14px */
+  --body-font-size-xxs: 1.3rem; /* 13px */
 
   /* Heading font sizes */
   --heading-font-size-scale: 0.5;
@@ -244,46 +207,24 @@ h1, h2, h3,
 h4, h5, h6,
 .h1, .h2, .h3,
 .h4, .h5, .h6 {
-  font-family: var(--ff-subheadings-medium);
+  font-family: var(--ff-headline-medium);
+  font-weight: 600;
+  line-height: 1.25;
   margin-top: 1em;
   margin-bottom: 0.5em;
   scroll-margin: calc(var(--nav-height-m) + 1em);
-  font-weight: normal;
 }
 
-h1, h2,
-.h1, .h2 {
+h1, h2 {
   font-family: var(--ff-headline-medium);
 }
 
-h1, .h1 {
-  font-size: var(--headline-1-font-size);
-  line-height: var(--headline-1-line-height);
-  letter-spacing: var(--headline-1-letter-spacing);
-}
-
-h2, .h2 {
-  font-size: var(--headline-2-font-size);
-  line-height: var(--headline-2-line-height);
-  letter-spacing: var(--headline-2-letter-spacing);
-}
-
-h3, .h3 {
-  font-size: var(--headline-3-font-size);
-  line-height: var(--headline-3-line-height);
-}
-
-h4, .h4 {
-  font-size: var(--headline-4-font-size);
-  line-height: var(--headline-4-line-height);
-}
-
-h5, .h5 {
-  font-size: var(--headline-5-font-size);
-  line-height: var(--headline-5-line-height);
-}
-
-h6, .h6 { font-size: var(--heading-font-size-xs); }
+h1 { font-size: var(--heading-font-size-xxl); }
+h2 { font-size: var(--heading-font-size-xl); }
+h3 { font-size: var(--heading-font-size-l); }
+h4 { font-size: var(--heading-font-size-m); }
+h5 { font-size: var(--heading-font-size-s); }
+h6 { font-size: var(--heading-font-size-xs); }
 
 p, dl, ol, ul, pre, blockquote {
   margin-top: 1em;
@@ -732,7 +673,7 @@ main sup {
 
 /* Section medatada styling */
 
-/* main .section.font-xxl {
+main .section.font-xxl {
   font-size: var(--body-font-size-xxl);
 }
 
@@ -758,7 +699,7 @@ main .section.font-xs {
 
 main .section.font-xxs {
   font-size: var(--body-font-size-xxs);
-} */
+}
 
 main .section.bg-paper {
   background: url("../media/bg-paper.webp");
@@ -824,25 +765,120 @@ main .section.responsive-title h1 {
   }
 }
 
-@media (min-width: 1200px) {
-  :root {
-    /* New design variables */
-    --headline-1-font-size: 2.813rem; /* 45px */
-    --headline-2-font-size: 2rem; /* 32px */
-    --headline-3-font-size: 2rem; /* 32px */
-    --testimonial-font-size: 1.5rem; /* 24px */
-  }
-}
-
 /* REDESIGN GLOBAL STYLES */
 .redesign-v2 {
   --v2-space-small: 16px;
   --color-icon: var(--c-primary-black);
   --color-icon-accent: var(--c-primary-gold);
-  --wrapper-width: 1040px;
 
   font-size: 16px;
+
+  /* Font sizes */
+
+  /* GT America, Extended Medium, 45px, 115%, -2% / 32px, 115%, -2% */
+  --headline-1-font-size: 2rem; /* 32px */
+
+  /* GT America, Extended Medium, 32px, 115%, -2% / 28px, 115%, -2% */
+  --headline-2-font-size: 1.75rem; /* 28px */
+
+  /* Helvetica Neue LT Pro, 65 Medium, 32px, 115% / 28px, 115% */
+  --headline-3-font-size: 1.75rem; /* 28px */
+
+  /* Helvetica Neue LT Pro, 65 Medium, 24px, 140%  */
+  --headline-4-font-size: 1.5rem; /* 24px */
+
+  /* Helvetica Neue LT Pro, 65 Medium, 18px, 140%  */
+  --headline-5-font-size: 1.125rem; /* 18px */
+
+  /* Body font sizes */
+  --body-font-size-xxl: 1.5rem; /* 24px */
+  --body-font-size-xl: 1.375rem; /* 22px */
+  --body-font-size-l: 1.25rem; /* 20px */
+  --body-font-size-m: 1.125rem; /* 18px */
+  --body-font-size-s: 1rem; /* 16px */
+  --body-font-size-xs: 0.875rem; /* 14px */
+  --body-font-size-xxs: 0.813rem; /* 13px */
+
+  /* Helvetica Neue LT Pro, 55 Roman / Helvetica Neue LT Pro, 75 Bold, 16px, 150%  */
+  --body-1-font-size: 1rem; /* 16px */
+  --body-1-line-height: 150%;
+
+  /* Helvetica Neue LT Pro, 55 Roman / Helvetica Neue LT Pro, 75 Bold, 13px, 160%  */
+  --body-2-font-size: 0.813rem; /* 13px */
+  --body-2-line-height: 160%;
+
+  /* GT America Mono, Regular, 18px, 120% */
+  --accent-1-font-size: 1.125rem; /* 18px */
+  --accent-1-line-height: 120%;
+
+  /* GT America Mono, Regular, 14px, 120% */
+  --accent-2-font-size: 0.875rem; /* 14px */
+  --accent-2-line-height: 120%;
+
+  /* Helvetica Neue LT Pro, 75 Bold, 14px, 16px */
+  --label-font-size: 0.875rem; /* 14px */
+  --label-line-height: 16px;
+  
+  /* Helvetica Neue LT Pro, 55 Roman, 14px, 18px */
+  --button-font-size: 0.875rem; /* 14px */
+  --button-line-height: 18px;
+
+  /* GT America, Extended Roman, 24px, 120%, -2% / 18px, 120%, -2% */
+  --testimonial-font-size: 1.125rem; /* 18px */
+  --testimonial-line-height: 120%;
+  --testimonial-letter-spacing: -2%;
+
+  /* Motions */
+  --duration-small: 160ms;
+  --duration-medium: 240ms;
+  --duration-large: 320ms;
+  --easing-entrance: cubic-bezier(0, 0, 0.4, 1);
+  --easing-exit: cubic-bezier(0.2, 0, 1, 1);
+  --easing-standard: cubic-bezier(0.2, 0, 0.1, 1);
+
+  /* In page navigation */
+  --inpage-navigation-height: 0;
 }
+
+/* stylelint-disable-next-line no-descending-specificity */
+.redesign-v2 h1, .redesign-v2 h2, .redesign-v2 h3,
+.redesign-v2 h4, .redesign-v2 h5, .redesign-v2 h6,
+.h1, .h2, .h3,
+.h4, .h5, .h6 {
+  font-family: var(--ff-subheadings-medium);
+  font-weight: normal;
+}
+
+/* stylelint-disable-next-line no-descending-specificity */
+.redesign-v2 h1, .h1 {
+  font-size: var(--headline-1-font-size);
+  line-height: var(--headline-1-line-height);
+  letter-spacing: var(--headline-1-letter-spacing);
+}
+
+/* stylelint-disable-next-line no-descending-specificity */
+.redesign-v2 h2, .h2 {
+  font-size: var(--headline-2-font-size);
+  line-height: var(--headline-2-line-height);
+  letter-spacing: var(--headline-2-letter-spacing);
+}
+
+/* stylelint-disable-next-line no-descending-specificity */
+.redesign-v2 h3, .h3 {
+  font-size: var(--headline-3-font-size);
+  line-height: var(--headline-3-line-height);
+}
+
+.redesign-v2 h4, .h4 {
+  font-size: var(--headline-4-font-size);
+  line-height: var(--headline-4-line-height);
+}
+
+.redesign-v2 h5, .h5 {
+  font-size: var(--headline-5-font-size);
+  line-height: var(--headline-5-line-height);
+}
+
 
 /* ICONS STYLES */
 
@@ -1016,6 +1052,17 @@ main .section.responsive-title h1 {
     width: 65px;
   }
 }
+
+@media (min-width: 1200px) {
+  .redesign-v2 {
+    /* New design variables */
+    --headline-1-font-size: 2.813rem; /* 45px */
+    --headline-2-font-size: 2rem; /* 32px */
+    --headline-3-font-size: 2rem; /* 32px */
+    --testimonial-font-size: 1.5rem; /* 24px */
+  }
+}
+
 
 /* CLS OPTIMIZATION */
 .v2-hero {

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -103,7 +103,7 @@
   --headline-4-line-height: 140%;
 
   /* Helvetica Neue LT Pro, 65 Medium, 18px, 140%  */
-  --headline-5-font-size: 1.125rem; /* 18px */
+  --headline-5-font-size: 1.8rem; /* 18px */
   --headline-5-line-height: 140%;
 
   /* Wrapper for generic components */
@@ -797,14 +797,17 @@ main .section.responsive-title h1 {
   --body-font-size-m: 1.125rem; /* 18px */
   --body-font-size-s: 1rem; /* 16px */
   --body-font-size-xs: 0.875rem; /* 14px */
-  --body-font-size-xxs: 0.813rem; /* 13px */
+
+  /* stylelint-disable-next-line number-max-precision */
+  --body-font-size-xxs: 0.8125rem; /* 13px */
 
   /* Helvetica Neue LT Pro, 55 Roman / Helvetica Neue LT Pro, 75 Bold, 16px, 150%  */
   --body-1-font-size: 1rem; /* 16px */
   --body-1-line-height: 150%;
 
   /* Helvetica Neue LT Pro, 55 Roman / Helvetica Neue LT Pro, 75 Bold, 13px, 160%  */
-  --body-2-font-size: 0.813rem; /* 13px */
+  /* stylelint-disable-next-line number-max-precision */
+  --body-2-font-size: 0.8125rem; /* 13px */
   --body-2-line-height: 160%;
 
   /* GT America Mono, Regular, 18px, 120% */
@@ -1056,7 +1059,8 @@ main .section.responsive-title h1 {
 @media (min-width: 1200px) {
   .redesign-v2 {
     /* New design variables */
-    --headline-1-font-size: 2.813rem; /* 45px */
+    /* stylelint-disable-next-line number-max-precision */
+    --headline-1-font-size: 2.8125rem; /* 45px */
     --headline-2-font-size: 2rem; /* 32px */
     --headline-3-font-size: 2rem; /* 32px */
     --testimonial-font-size: 1.5rem; /* 24px */


### PR DESCRIPTION
Fix #77 #78

Test URLs:
- Before: https://main--vg-macktrucks-com-rd--netcentric.hlx.page/
- After: https://78-bug-footer-and-font-sizes--vg-macktrucks-com-rd--netcentric.hlx.page/

Redesign-only custom properties (CSS variables) are moved down in the CSS file, to prevent more regression being created. All font-sizes returned to former values, reflecting state on live website. Overrides are placed accordingly.