### PR TITLE
102 index all trucks

### DIFF
--- a/helix-query.yaml
+++ b/helix-query.yaml
@@ -105,7 +105,7 @@ indices:
     include:
       - '/trucks/**'
     exclude:
-      - '/trucks/*/**'
+      - '/trucks/*/*/'
     target: /all-trucks.json
     properties:
       title:

--- a/helix-query.yaml
+++ b/helix-query.yaml
@@ -101,6 +101,34 @@ indices:
       lastModified:
         select: none
         value: parseTimestamp(headers["last-modified"], "ddd, DD MMM YYYY hh:mm:ss GMT")
+  all-trucks:
+    include:
+      - '/trucks/**'
+    exclude:
+      - '/trucks/*/**'
+    target: /all-trucks.json
+    properties:
+      title:
+        select: head > meta[property="og:title"]
+        value: attribute(el, "content")
+      description:
+        select: head > meta[property="og:description"]
+        value: attribute(el, "content")
+      model:
+        select: head > meta[name="model"]
+        value: attribute(el, "content")
+      segment:
+        select: head > meta[name="segment"]
+        values: attribute(el, "content")
+      builder:
+        select: head > meta[name="builder"]
+        value: attribute(el, "content")
+      image:
+        select: head > meta[property="og:image"]
+        value: match(attribute(el, "content"), "https:\/\/[^/]+(/.*)")
+      lastModified:
+        select: none
+        value: parseTimestamp(headers["last-modified"], "ddd, DD MMM YYYY hh:mm:ss GMT")
   search:
     include:
       - '/**'


### PR DESCRIPTION
Fix #102 

Updated helix-query.yaml file with new index to get additional metadata elements from PDP pages:

<img width="646" alt="image" src="https://github.com/Netcentric/vg-macktrucks-com-rd/assets/116451851/06eacb40-b993-4ef0-abea-a5ce3cbedb27">


Test URLs:
- Before: https://main--vg-macktrucks-com-rd--netcentric.hlx.page/
- After: https://102-index-all-trucks--vg-macktrucks-com-rd--netcentric.hlx.page/
