### PR TITLE
#55 All trucks - Increase the page title top padding

### DIFF
--- a/blocks/v2-all-trucks/v2-all-trucks.css
+++ b/blocks/v2-all-trucks/v2-all-trucks.css
@@ -8,7 +8,7 @@
   font-family: var(--ff-headline-medium);
   letter-spacing: -.02em;
   margin-bottom: 24px;
-  padding-top: 32px;
+  padding-top: 42px;
 }
 
 .redesign-v2 .section.v2-all-trucks-container .default-content-wrapper h1 + p {


### PR DESCRIPTION
Increase the page title top padding for red marker to become visible bellow the header

Fix #55 

Test URLs:
- Before: https://develop--vg-macktrucks-com--netcentric.hlx.page/
- After: https://55-all-trucks-listing--vg-macktrucks-com-rd--netcentric.hlx.page/drafts/marko/v2/all-trucks