### PR TITLE
Cards Block Variant: 3-card row with button #115

### DIFF
--- a/blocks/v2-cards/v2-cards.css
+++ b/blocks/v2-cards/v2-cards.css
@@ -54,6 +54,11 @@
   margin: 0 0 7px;
 }
 
+.v2-cards--large-heading .v2-cards__heading {
+  font-size: var(--headline-4-font-size);
+  line-height: var(--headline-4-line-height);
+}
+
 .v2-cards__text-wrapper p {
   margin: 0;
   color: var(--c-primary-black);

--- a/blocks/v2-cards/v2-cards.js
+++ b/blocks/v2-cards/v2-cards.js
@@ -2,7 +2,7 @@ import { variantsClassesToBEM } from '../../scripts/common.js';
 
 export default async function decorate(block) {
   const blockName = 'v2-cards';
-  const variantClasses = ['no-background', 'gray-cards', 'horizontal', 'image-aspect-ratio-7-5'];
+  const variantClasses = ['no-background', 'gray-cards', 'horizontal', 'image-aspect-ratio-7-5', 'large-heading'];
   variantsClassesToBEM(block.classList, variantClasses, blockName);
 
   const cardsItems = [...block.querySelectorAll(':scope > div')];


### PR DESCRIPTION
Fix #115 

Test URLs:
- Before: https://main--vg-macktrucks-com-rd--netcentric.hlx.page/drafts/syb/cards
- After: https://115-cards-with-button--vg-macktrucks-com-rd--netcentric.hlx.page/drafts/syb/cards

I’ve added three variants:
1. `no-background` for removing background of cards and its padding
2. `image-aspect-ratio-7-5` to change from 16/9 aspect ratio for images to 7/5
3. `large-heading` for having a h4-style heading

The latter I’m not happy with. I’d rather utilise the CSS class h4 here, but I’m running into specificity issues.

Then, I’ve added a possibility to add buttons in cards. [As per documentation](https://www.aem.live/developer/block-collection/buttons#content-structure) I’m utilising strong/emphasis elements for the primary/secondary button. The normal state will be the standalone link.