### PR TITLE
Add configuration to .gitignore for release #170

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,8 @@ node_modules
 helix-importer-ui
 .DS_Store
 .idea/*
+
+fstab.yaml
+pull_request_template.md
+README.md
+config.json


### PR DESCRIPTION
Fix #170 

Test URLs:
- Before: https://develop--vg-macktrucks-com-rd--netcentric.hlx.page/
- After: https://170-ignore-path-changes--vg-macktrucks-com-rd--netcentric.hlx.page/
