### PR TITLE
Hero variant for Solutions page #45

### DIFF
--- a/blocks/v2-all-trucks/v2-all-trucks.css
+++ b/blocks/v2-all-trucks/v2-all-trucks.css
@@ -1,19 +1,10 @@
 /* All trucks styles */
 
-.v2-all-trucks-container .default-content-wrapper {
-  margin-top: 35px;
-}
-
 .v2-all-trucks__title {
   font-family: var(--ff-headline-medium);
   letter-spacing: -.02em;
   margin-bottom: 24px;
   padding-top: 42px;
-}
-
-.redesign-v2 .section.v2-all-trucks-container .default-content-wrapper h1 + p {
-  letter-spacing: .01rem;
-  margin-bottom: 30px;
 }
 
 .v2-all-trucks .v2-all-trucks__button-list {
@@ -37,7 +28,6 @@
   text-align: left;
   width: 100%;
 }
-
 
 /* Trucks */
 .v2-all-trucks-container div.v2-all-trucks-wrapper {

--- a/blocks/v2-all-trucks/v2-all-trucks.js
+++ b/blocks/v2-all-trucks/v2-all-trucks.js
@@ -4,9 +4,6 @@ import { createElement, getTextLabel } from '../../scripts/common.js';
 const blockName = 'v2-all-trucks';
 
 export default function decorate(block) {
-  const pageDescriptionHeading = document.querySelector(`.${blockName}-container > div > h1`);
-  pageDescriptionHeading.classList.add('with-marker', `${blockName}__title`);
-
   const truckElement = block.querySelectorAll(`.${blockName} > div`);
   truckElement.forEach((div) => {
     div.classList.add(`${blockName}__truck`);

--- a/blocks/v2-hero/v2-hero.css
+++ b/blocks/v2-hero/v2-hero.css
@@ -44,24 +44,9 @@
   letter-spacing: -0.56px;
 }
 
-.v2-hero__cta-wrapper {
+.v2-hero__cta-wrapper,
+.v2-hero__cta-wrapper a.button {
   margin: 0;
-}
-
-.v2-hero .v2-hero__cta:any-link {
-  margin: 0;
-  padding: 2px 20px 0;
-  height: 48px;
-  display: inline-flex;
-  align-items: center;
-  color: var(--c-primary-white);
-  text-align: center;
-  font-family: var(--ff-subheadings-medium);
-  font-size: 14px;
-  font-style: normal;
-  line-height: 18px;
-  letter-spacing: 1.12px;
-  border-radius: 2px;
 }
 
 @media (min-width: 1200px) {

--- a/blocks/v2-hero/v2-hero.css
+++ b/blocks/v2-hero/v2-hero.css
@@ -21,7 +21,7 @@
 }
 
 .v2-hero__content {
-  color: var(--c-primary-white);
+  color: var(--text-color-white);
   padding: 40px 16px;
   display: flex;
   flex-direction: column;
@@ -29,15 +29,18 @@
   width: 100%;
 }
 
+.v2-hero__content * {
+  max-width: 600px;
+}
+
 .v2-hero__heading {
   margin: 24px 0;
-  color: var(--c-primary-white);
+  color: var(--text-color-white);
   font-family: var(--ff-headline-medium);
   font-size: 28px;
   font-style: normal;
   line-height: 120%;
   letter-spacing: -0.56px;
-  max-width: 600px;
 }
 
 .v2-hero__cta-wrapper {
@@ -50,7 +53,7 @@
   height: 48px;
   display: inline-flex;
   align-items: center;
-  color: var(--c-primary-white);
+  color: var(--text-color-white);
   text-align: center;
   font-family: var(--ff-subheadings-medium);
   font-size: 14px;
@@ -113,7 +116,7 @@
   justify-content: space-between;
   background-color: rgb(29 29 29 / 85%);
   list-style-type: none;
-  color: var(--c-primary-white);
+  color: var(--text-color-white);
   margin: 0;
   padding: 35px 40px 40px;
   text-align: center;
@@ -267,28 +270,27 @@
 }
 
 /* Dark and Light Variants */
-.v2-hero.v2-hero--dark .v2-hero__content,
-.v2-hero.v2-hero--dark .v2-hero__heading {
-  color: var(--c-primary-white);
+/* stylelint-disable-next-line no-descending-specificity */
+.v2-hero--dark .v2-hero__content,
+.v2-hero--dark .v2-hero__heading {
+  color: var(--text-color-white);
 }
 
-.v2-hero.v2-hero--light .v2-hero__content,
-.v2-hero.v2-hero--light .v2-hero__heading {
-  color: var(--c-primary-black);
+/* stylelint-disable-next-line no-descending-specificity */
+.v2-hero--light .v2-hero__content,
+.v2-hero--light .v2-hero__heading {
+  color: var(--text-color-black);
 }
 
-.v2-hero.v2-hero--dark .v2-hero__content-wrapper {
+.v2-hero--dark .v2-hero__content-wrapper {
   background: linear-gradient(180deg, transparent 56.46%, rgba(0 0 0 / 50%) 100%);
 }
 
-.v2-hero.v2-hero--light .v2-hero__content-wrapper {
+.v2-hero--light .v2-hero__content-wrapper {
   background: linear-gradient(180deg, transparent 56.46%, rgba(255 255 255 / 50%) 100%);
 }
 
 /* Hero with text styling */
-.v2-hero__content.with-text .v2-hero__heading {
-  margin-bottom: 24px;
-}
 
 .v2-hero__content.with-text .v2-hero__text {
   word-wrap: break-word;
@@ -304,27 +306,17 @@
 .v2-hero.no-image .v2-hero__content-wrapper,
 .v2-hero.no-image.v2-hero--dark .v2-hero__content-wrapper {
   background-color: var(--c-primary-black);
-  color: var(--c-primary-black);
+  color: var(--text-color-black);
 }
 
 .v2-hero.no-image.v2-hero--light .v2-hero__content-wrapper {
   background-color: var(--c-primary-white);
-  color: var(--c-primary-white);
-}
-
-@media (min-width: 744px) {
-  .v2-hero__content.with-text .v2-hero__text {
-    width: 60%;
-  }
+  color: var(--text-color-white);
 }
 
 @media (min-width: 1200px) {
   .v2-hero.no-image .v2-hero__content {
-    padding-bottom: 40px;
-  }
-
-  .v2-hero.no-image .v2-hero__content-wrapper {
-    padding-top: 40px;
+    padding: 40px 0;
   }
 }
 

--- a/blocks/v2-hero/v2-hero.css
+++ b/blocks/v2-hero/v2-hero.css
@@ -292,7 +292,7 @@
 
 .v2-hero__content.with-text .v2-hero__text {
   word-wrap: break-word;
-  letter-spacing: .16px;
+  letter-spacing: .01rem;
   margin: 0;
 }
 
@@ -319,10 +319,6 @@
 }
 
 @media (min-width: 1200px) {
-  .v2-hero__content.with-text .v2-hero__text {
-    width: 42%;
-  }
-
   .v2-hero.no-image .v2-hero__content {
     padding-bottom: 40px;
   }

--- a/blocks/v2-hero/v2-hero.css
+++ b/blocks/v2-hero/v2-hero.css
@@ -31,7 +31,7 @@
   width: 100%;
 }
 
-.v2-hero__content * {
+.v2-hero-container:not([data-page='pdp']) .v2-hero__content * {
   max-width: 600px;
 }
 
@@ -42,6 +42,22 @@
   font-style: normal;
   line-height: 120%;
   letter-spacing: -0.56px;
+}
+
+.v2-hero .v2-hero__cta:any-link {
+  margin: 0;
+  padding: 2px 20px 0;
+  height: 48px;
+  display: inline-flex;
+  align-items: center;
+  color: var(--c-primary-white);
+  text-align: center;
+  font-family: var(--ff-subheadings-medium);
+  font-size: 14px;
+  font-style: normal;
+  line-height: 18px;
+  letter-spacing: 1.12px;
+  border-radius: 2px;
 }
 
 .v2-hero__cta-wrapper {

--- a/blocks/v2-hero/v2-hero.css
+++ b/blocks/v2-hero/v2-hero.css
@@ -44,7 +44,10 @@
   letter-spacing: -0.56px;
 }
 
-.v2-hero__cta-wrapper,
+.v2-hero__cta-wrapper {
+  margin: 16px 0 0;
+}
+
 .v2-hero__cta-wrapper a.button {
   margin: 0;
 }
@@ -56,7 +59,7 @@
   }
 
   .v2-hero__heading {
-    margin: 18px 0 41px;
+    margin: 18px 0 24px;
     line-height: 1.15;
     font-size: 45px;
     letter-spacing: -0.9px;

--- a/blocks/v2-hero/v2-hero.css
+++ b/blocks/v2-hero/v2-hero.css
@@ -54,7 +54,7 @@
   height: 48px;
   display: inline-flex;
   align-items: center;
-  color: var(--text-color);
+  color: var(--c-primary-white);
   text-align: center;
   font-family: var(--ff-subheadings-medium);
   font-size: 14px;

--- a/blocks/v2-hero/v2-hero.css
+++ b/blocks/v2-hero/v2-hero.css
@@ -21,6 +21,7 @@
 }
 
 .v2-hero__content {
+  color: var(--c-primary-white);
   padding: 40px 16px;
   display: flex;
   flex-direction: column;
@@ -263,6 +264,72 @@
 
 [data-page='pdp'][data-page-variation-standard='is-standard-model'][data-model-variation="has-electric-model"] .v2-hero__cta-wrapper {
   display: block;
+}
+
+/* Dark and Light Variants */
+.v2-hero.v2-hero--dark .v2-hero__content,
+.v2-hero.v2-hero--dark .v2-hero__heading {
+  color: var(--c-primary-white);
+}
+
+.v2-hero.v2-hero--light .v2-hero__content,
+.v2-hero.v2-hero--light .v2-hero__heading {
+  color: var(--c-primary-black);
+}
+
+.v2-hero.v2-hero--dark .v2-hero__content-wrapper {
+  background: linear-gradient(180deg, transparent 56.46%, rgba(0 0 0 / 50%) 100%);
+}
+
+.v2-hero.v2-hero--light .v2-hero__content-wrapper {
+  background: linear-gradient(180deg, transparent 56.46%, rgba(255 255 255 / 50%) 100%);
+}
+
+/* Hero with text styling */
+.v2-hero__content.with-text .v2-hero__heading {
+  margin-bottom: 24px;
+}
+
+.v2-hero__content.with-text .v2-hero__text {
+  word-wrap: break-word;
+  letter-spacing: .16px;
+  margin: 0;
+}
+
+/* Hero with no image */
+.v2-hero.no-image {
+  height: unset;
+}
+
+.v2-hero.no-image .v2-hero__content-wrapper,
+.v2-hero.no-image.v2-hero--dark .v2-hero__content-wrapper {
+  background-color: var(--c-primary-black);
+  color: var(--c-primary-black);
+}
+
+.v2-hero.no-image.v2-hero--light .v2-hero__content-wrapper {
+  background-color: var(--c-primary-white);
+  color: var(--c-primary-white);
+}
+
+@media (min-width: 744px) {
+  .v2-hero__content.with-text .v2-hero__text {
+    width: 60%;
+  }
+}
+
+@media (min-width: 1200px) {
+  .v2-hero__content.with-text .v2-hero__text {
+    width: 42%;
+  }
+
+  .v2-hero.no-image .v2-hero__content {
+    padding-bottom: 40px;
+  }
+
+  .v2-hero.no-image .v2-hero__content-wrapper {
+    padding-top: 40px;
+  }
 }
 
 /* PDP - electric model stats bar END */

--- a/blocks/v2-hero/v2-hero.css
+++ b/blocks/v2-hero/v2-hero.css
@@ -1,4 +1,6 @@
 .v2-hero {
+  --text-color: var(--c-primary-white);
+  
   /* height of the hero block is set in main style to prevent CLS */
   position: relative;
   overflow: hidden;
@@ -21,7 +23,7 @@
 }
 
 .v2-hero__content {
-  color: var(--text-color-white);
+  color: var(--text-color);
   padding: 40px 16px;
   display: flex;
   flex-direction: column;
@@ -35,7 +37,6 @@
 
 .v2-hero__heading {
   margin: 24px 0;
-  color: var(--text-color-white);
   font-family: var(--ff-headline-medium);
   font-size: 28px;
   font-style: normal;
@@ -53,7 +54,7 @@
   height: 48px;
   display: inline-flex;
   align-items: center;
-  color: var(--text-color-white);
+  color: var(--text-color);
   text-align: center;
   font-family: var(--ff-subheadings-medium);
   font-size: 14px;
@@ -116,7 +117,7 @@
   justify-content: space-between;
   background-color: rgb(29 29 29 / 85%);
   list-style-type: none;
-  color: var(--text-color-white);
+  color: var(--text-color);
   margin: 0;
   padding: 35px 40px 40px;
   text-align: center;
@@ -270,16 +271,8 @@
 }
 
 /* Dark and Light Variants */
-/* stylelint-disable-next-line no-descending-specificity */
-.v2-hero--dark .v2-hero__content,
-.v2-hero--dark .v2-hero__heading {
-  color: var(--text-color-white);
-}
-
-/* stylelint-disable-next-line no-descending-specificity */
-.v2-hero--light .v2-hero__content,
-.v2-hero--light .v2-hero__heading {
-  color: var(--text-color-black);
+.v2-hero--light {
+  --text-color: var(--c-primary-black);
 }
 
 .v2-hero--dark .v2-hero__content-wrapper {
@@ -306,12 +299,10 @@
 .v2-hero.no-image .v2-hero__content-wrapper,
 .v2-hero.no-image.v2-hero--dark .v2-hero__content-wrapper {
   background-color: var(--c-primary-black);
-  color: var(--text-color-black);
 }
 
 .v2-hero.no-image.v2-hero--light .v2-hero__content-wrapper {
   background-color: var(--c-primary-white);
-  color: var(--text-color-white);
 }
 
 @media (min-width: 1200px) {

--- a/blocks/v2-hero/v2-hero.js
+++ b/blocks/v2-hero/v2-hero.js
@@ -69,7 +69,7 @@ export default async function decorate(block) {
 
   const ctaButtons = content.querySelectorAll('.button-container > a');
   [...ctaButtons].forEach((b) => {
-    b.classList.add(`${blockName}__cta`, 'button--cta');
+    b.classList.add('button--cta', 'button--large');
     b.classList.remove('button--primary');
     b.parentElement.classList.add(`${blockName}__cta-wrapper`);
   });

--- a/blocks/v2-hero/v2-hero.js
+++ b/blocks/v2-hero/v2-hero.js
@@ -9,6 +9,8 @@ const blockName = 'v2-hero';
 
 export default async function decorate(block) {
   variantsClassesToBEM(block.classList, variantClasses, blockName);
+  const blockContainer = block.parentElement.parentElement;
+  const isPdp = blockContainer.dataset.page === 'pdp';
 
   const images = [...block.querySelectorAll('p > picture')];
   const imageURLs = getImageURLs(images);
@@ -69,7 +71,7 @@ export default async function decorate(block) {
 
   const ctaButtons = content.querySelectorAll('.button-container > a');
   [...ctaButtons].forEach((b) => {
-    b.classList.add('button--cta', 'button--large');
+    b.classList.add((isPdp ? `${blockName}__cta` : 'button--large'), 'button--cta');
     b.classList.remove('button--primary');
     b.parentElement.classList.add(`${blockName}__cta-wrapper`);
   });

--- a/blocks/v2-hero/v2-hero.js
+++ b/blocks/v2-hero/v2-hero.js
@@ -1,10 +1,15 @@
 import {
   getImageURLs,
   createResponsivePicture,
+  variantsClassesToBEM,
 } from '../../scripts/common.js';
 
+const variantClasses = ['dark', 'light'];
+const blockName = 'v2-hero';
+
 export default async function decorate(block) {
-  const blockName = 'v2-hero';
+  variantsClassesToBEM(block.classList, variantClasses, blockName);
+
   const images = [...block.querySelectorAll('p > picture')];
   const imageURLs = getImageURLs(images);
   const imageData = imageURLs.map((src) => ({ src, breakpoints: [] }));
@@ -36,7 +41,11 @@ export default async function decorate(block) {
   const newPicture = createResponsivePicture(imageData, true, altText, `${blockName}__image`);
   images.forEach((image) => image.parentNode.remove());
 
-  block.prepend(newPicture);
+  if (images.length !== 0) {
+    block.prepend(newPicture);
+  } else {
+    block.classList.add('no-image');
+  }
 
   const contentWrapper = block.querySelector(':scope > div');
   contentWrapper.classList.add(`${blockName}__content-wrapper`);
@@ -49,6 +58,14 @@ export default async function decorate(block) {
 
   const firstHeading = headings[0];
   firstHeading.classList.add('with-marker');
+
+  const button = content.querySelector('a');
+  const allTexts = content.querySelectorAll('p');
+
+  if (!button && (allTexts.length > 0)) {
+    content.classList.add('with-text');
+    allTexts.forEach((p) => p.classList.add(`${blockName}__text`));
+  }
 
   const ctaButtons = content.querySelectorAll('.button-container > a');
   [...ctaButtons].forEach((b) => {

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -35,7 +35,8 @@
 
   /* Applied colors */
   --background-color: var(--c-primary-white);
-  --text-color: var(--c-primary-black);
+  --text-color-black: var(--c-primary-black);
+  --text-color-white: var(--c-primary-white);
   --link-color: var(--c-accent-red);
   --link-hover-color: var(--c-primary-black);
   --header-color: var(--c-primary-white);

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -35,8 +35,7 @@
 
   /* Applied colors */
   --background-color: var(--c-primary-white);
-  --text-color-black: var(--c-primary-black);
-  --text-color-white: var(--c-primary-white);
+  --text-color: var(--c-primary-black);
   --link-color: var(--c-accent-red);
   --link-hover-color: var(--c-primary-black);
   --header-color: var(--c-primary-white);


### PR DESCRIPTION
-Added a dark and light variants to the hero and also styled the cases where there is just text or no image present.
-Refactored the 'all-trucks' block. Now the hero is independent of this block's h1 tag.

Fix #45

Test URLs:
- Before: https://main--vg-macktrucks-com-rd--netcentric.hlx.page/drafts/shomps/hero-variant
- After: https://45-hero-variant--vg-macktrucks-com-rd--netcentric.hlx.page/drafts/shomps/hero-variant

- Before: https://main--vg-macktrucks-com-rd--netcentric.hlx.page/drafts/shomps/all-trucks-testing
- After: https://45-hero-variant--vg-macktrucks-com-rd--netcentric.hlx.page/drafts/shomps/all-trucks-testing
