### PR TITLE
Half grey columns variant #136

### DIFF
--- a/blocks/v2-columns/v2-columns.css
+++ b/blocks/v2-columns/v2-columns.css
@@ -1,3 +1,7 @@
+.v2-columns-container {
+  overflow: hidden;
+}
+
 .v2-columns-container.section--with-background {
   position: relative;
 }
@@ -18,11 +22,23 @@
 }
 
 .v2-columns__column--with-image {
+  position: relative;
   order: 0;
 }
 
 .v2-columns__column--with-image img {
   display: block;
+}
+
+.v2-columns--background-plane .v2-columns__column--with-image::after {
+  content: '';
+  position: absolute;
+  top: 0;
+  left: -16px;
+  right: -16px;
+  z-index: -1;
+  height: 50%;
+  background-color: var(--c-secondary-silver);
 }
 
 .v2-columns__column--with-text .icon,
@@ -101,6 +117,18 @@
     width: 100%;
     padding: 0;
     order: unset;
+  }
+
+  .v2-columns--background-plane .v2-columns__column--with-image::after {
+    right: 50%;
+    left: auto;
+    width: 100%;
+    height: 100%;
+  }
+
+  .v2-columns--background-plane .v2-columns__column--with-text + .v2-columns__column--with-image::after {
+    right: auto;
+    left: 50%;
   }
 
   .v2-columns .v2-columns__column--with-text {

--- a/blocks/v2-columns/v2-columns.css
+++ b/blocks/v2-columns/v2-columns.css
@@ -2,6 +2,12 @@
   overflow: hidden;
 }
 
+/* TODO: refactor generic section/block paddings */
+.v2-columns-container.padding-0 > div {
+  padding-top: 0;
+  padding-bottom: 0;
+}
+
 .v2-columns-container.section--with-background {
   position: relative;
 }
@@ -92,7 +98,6 @@
 }
 
 .v2-columns__column--with-text a.button {
-  min-width: auto;
   margin: 0;
 }
 

--- a/blocks/v2-columns/v2-columns.js
+++ b/blocks/v2-columns/v2-columns.js
@@ -1,10 +1,10 @@
-import { variantsClassesToBEM, createElement } from '../../scripts/common.js';
+import { createElement, variantsClassesToBEM } from '../../scripts/common.js';
 
 export default async function decorate(block) {
   const blockParent = block.parentElement.parentElement;
   const blockName = 'v2-columns';
 
-  const variantClasses = ['with-background-image'];
+  const variantClasses = ['with-background-image', 'background-plane'];
   variantsClassesToBEM(block.classList, variantClasses, blockName);
 
   const isBackgroundImageVariant = block.classList.contains(`${blockName}--with-background-image`);


### PR DESCRIPTION
Fix #136

Test URLs:
- Before: https://develop--vg-macktrucks-com-rd--netcentric.hlx.page/block-library/blocks/v2-columns
- After: https://136-columns-variant--vg-macktrucks-com-rd--netcentric.hlx.page/block-library/blocks/v2-columns

In context on a page:
- Before: https://develop--vg-macktrucks-com-rd--netcentric.hlx.page/drafts/syb/diesel-powertrains
- After: https://136-columns-variant--vg-macktrucks-com-rd--netcentric.hlx.page/drafts/syb/diesel-powertrains

The usage is the same as the regular V2 Column block. We add a modifier to the block (background-plane) for the gray background to appear. I’m open for suggestions of renaming this :)